### PR TITLE
docs: document external CLI dependencies in Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ Your council of agents - Concilium!
 - A C toolchain only if `node-pty`'s prebuilt binaries aren't available for
   your platform; on macOS arm64/x64 and Linux x64/arm64 the prebuilds are used
 
+External CLIs the server invokes (must be on `$PATH`):
+
+- **`git`** — required. Used to read `origin` / `upstream` remotes when
+  detecting the GitHub repo for a card's working directory.
+- **`gh`** ([GitHub CLI](https://cli.github.com/)) — optional but recommended.
+  Authenticated (`gh auth login`) so it can call `gh agent-task list` to power
+  the active-agent indicator on PR rows. Without it, the rest of the GitHub
+  card still works; the 🤖 indicator just never shows.
+- **`zenity`** — Linux only, optional. Powers the OS folder picker (📂) on
+  GNU/Linux desktops. Without it, type or paste paths into the cwd field.
+  On macOS the picker uses built-in `osascript`; on Windows it uses built-in
+  `powershell`.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds an **External CLIs the server invokes** subsection under Requirements listing `git` (required), `gh` (optional, gates the active-agent indicator), and `zenity` (Linux-only optional folder picker).
- Notes inline that the macOS (`osascript`) and Windows (`powershell`) pickers ship with the OS, so they're not mistaken for additional installs.

## Merge order

This PR depends on **#44** for the `gh` requirement to be accurate — please merge #44 first, then this. If #44 lands with a different design that doesn't use `gh`, the `gh` bullet here should be revised before merging.

## Test plan

- [ ] Render the README on GitHub and confirm the new subsection lists `git`, `gh`, and `zenity` correctly under **Requirements**.
- [ ] Confirm there are no other unintended changes (`git diff trunk...HEAD` should show one section added in `README.md` only).