### PR TITLE
Add preferred code editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Your council of agents — Concilium!
   Card controls are compact icon buttons: 📂 opens the OS folder picker for
   the working directory, ▶ starts the task (turns red while a task is
   running, click to kill), **>_** opens a pop-out terminal card (see
-  below), and **⤢** expands a single card to fill the main area with a
+  below), **`</>`** opens the current working directory in your configured
+  editor on the local loopback UI, and **⤢** expands a single card to fill the main area with a
   smooth View Transitions animation between states. When the working
   directory resolves to a GitHub repo (via `git remote`), a GitHub
   (octocat) button appears in the card header: clicking it opens a GitHub
@@ -173,7 +174,7 @@ State lives entirely under `~/.concilium/`:
 
 ```
 ~/.concilium/
-├── config.yaml      # port + optional githubToken + agent list
+├── config.yaml      # port + optional githubToken + optional preferredEditor + agent list
 ├── tasks.db         # SQLite history + saved card layout
 ├── logs/<id>.log    # per-task plain-text output log
 ├── server.log       # the server's own stdout/stderr
@@ -200,6 +201,7 @@ agents:
 `interactive: false` → stdin is piped in, then closed (one-shot).
 `interactive: true` → spawned under a PTY; stays alive for follow-up input.
 `githubToken` is optional and used for authenticated GitHub API requests.
+`preferredEditor` is optional and used by the **`</>`** card button on the local loopback UI.
 
 Edits via the UI take effect immediately. Editing the YAML by hand requires
 a restart (`conciliumctl restart`).
@@ -227,6 +229,9 @@ All endpoints are JSON; loopback only.
 | `POST`   | `/api/tasks/:id/resize` | resize the PTY `{cols, rows}` (PTY mode only) |
 | `GET`    | `/api/stream/:id` | SSE: replays past events then streams live |
 | `POST`   | `/api/system/pick-directory` | open the OS folder picker, returns `{path}` |
+| `GET`    | `/api/system/preferred-editor` | get the local-loopback preferred editor setting and whether it is configured |
+| `POST`   | `/api/system/preferred-editor` | save/clear the local-loopback preferred editor `{command, args?}` |
+| `POST`   | `/api/system/open-editor` | open `{path}` in the configured preferred editor (local loopback UI only) |
 | `POST`   | `/api/system/github-url` | `{path}` → `{url}` if the directory's `origin`/`upstream` remote points at GitHub |
 | `POST`   | `/api/system/github-items` | `{url}` → `{issues, pulls}` for open GitHub issues/pull requests |
 | `POST`   | `/api/system/github-pulls/action` | trigger a pull request action with `{url, pullNumber, action, sha?, mergeMethod?, nodeId?}`; `action` is `"merge"`, `"close"`, or `"mark_ready"` |

--- a/docs/using-concilium.md
+++ b/docs/using-concilium.md
@@ -7,7 +7,9 @@
 3. Set the working directory (📂 or type/paste a path).
 4. Enter your prompt and click **▶** to start.
 
-Use **>_** to open a side terminal in the same working directory.
+Use **>_** to open a side terminal in the same working directory. If you save a
+preferred editor in Settings, use **`</>`** to open that directory in your editor
+from the local loopback UI.
 
 ## Running Concilium
 
@@ -54,6 +56,7 @@ Header controls:
 - **Gear (⚙)** — opens a settings dialog where you can:
   - Add, edit, or delete agents
   - Scan `$PATH` for known CLI agents and add the ones found
+  - Configure a preferred code editor command for the **`</>`** card button on the local loopback UI
   - Set or clear an optional `githubToken` used for authenticated GitHub API calls
 - **⌨** — opens the keyboard shortcuts help dialog.
 

--- a/public/app.js
+++ b/public/app.js
@@ -8,6 +8,8 @@ let activeCardEl = null;
 
 let layoutReady = false;
 let homeDir = '';
+let canUsePreferredEditor = isLoopbackOrigin();
+let preferredEditorConfigured = false;
 const IS_MAC = /mac/i.test(navigator.userAgentData?.platform || navigator.platform || '');
 const COPILOT_ISSUE_ASSIGNEE_LOGINS = new Set(['copilot', 'copilot-swe-agent[bot]']);
 const NEW_GITHUB_REPO_URL = 'https://github.com/new';
@@ -28,6 +30,11 @@ function currentTermTheme() {
     cursor: styles.getPropertyValue('--term-cursor').trim() || '#dddddd',
     selectionBackground: styles.getPropertyValue('--term-selection').trim() || 'rgba(120,180,255,0.30)',
   };
+}
+
+function isLoopbackOrigin() {
+  const host = (window.location.hostname || '').toLowerCase();
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]';
 }
 
 function formatUptime(seconds) {
@@ -281,6 +288,7 @@ class Card {
     this.githubBtn = $('.card-github', this.el);
     this.runBtn = $('.card-run', this.el);
     this.openTermBtn = $('.card-open-term', this.el);
+    this.openEditorBtn = $('.card-open-editor', this.el);
     this.cloneBtn = $('.card-clone', this.el);
     this.closeBtn = $('.card-close', this.el);
     this.expandBtn = $('.card-expand', this.el);
@@ -315,10 +323,15 @@ class Card {
     this.closeBtn.addEventListener('click', () => this.close());
     this.expandBtn.addEventListener('click', () => this.toggleExpand());
     this.openTermBtn.addEventListener('click', () => this.openTerminalCard());
+    this.openEditorBtn.addEventListener('click', () => this.openEditor());
     this.cloneBtn.addEventListener('click', () => cloneCard(this));
     this.githubBtn.addEventListener('click', () => this.openGitHubCard());
     this.agentSelect.addEventListener('change', () => saveLayout());
-    this.cwd.addEventListener('input', () => { saveLayout(); this.scheduleCheckGitHub(); });
+    this.cwd.addEventListener('input', () => {
+      saveLayout();
+      this.updatePreferredEditorButton();
+      this.scheduleCheckGitHub();
+    });
     this.cwd.addEventListener('keydown', (keyboardEvent) => {
       if (keyboardEvent.key === 'Enter' && !this.currentTaskId) {
         keyboardEvent.preventDefault();
@@ -329,6 +342,7 @@ class Card {
 
     cards.add(this);
     this.syncLinkedCardButtons();
+    this.updatePreferredEditorButton();
   }
 
   // Must be called AFTER the card element is attached to the DOM, so the
@@ -443,6 +457,34 @@ class Card {
     this.linkedTerminalCard = card;
     this.syncLinkedCardButtons();
     return card;
+  }
+
+  updatePreferredEditorButton() {
+    const shouldShow = canUsePreferredEditor && preferredEditorConfigured;
+    this.openEditorBtn.hidden = !shouldShow;
+    this.openEditorBtn.disabled = !shouldShow || !this.cwd.value.trim();
+  }
+
+  async openEditor() {
+    const directoryPath = this.cwd.value.trim();
+    if (!directoryPath) return;
+    this.openEditorBtn.disabled = true;
+    try {
+      const response = await fetch('/api/system/open-editor', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: directoryPath }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        this.setStatus(data.error || 'editor failed', 'err');
+      }
+    } catch (err) {
+      console.error('[concilium] openEditor failed:', err);
+      this.setStatus('editor failed', 'err');
+    } finally {
+      this.updatePreferredEditorButton();
+    }
   }
 
   async run() {
@@ -631,7 +673,12 @@ class Card {
       const response = await fetch('/api/system/pick-directory', { method: 'POST' });
       const data = await response.json().catch(() => ({}));
       if (!response.ok) { this.setStatus(data.error || 'browse failed', 'err'); return; }
-      if (data.path) { this.cwd.value = toTildePath(data.path); saveLayout(); this.checkGitHub(); }
+      if (data.path) {
+        this.cwd.value = toTildePath(data.path);
+        this.updatePreferredEditorButton();
+        saveLayout();
+        this.checkGitHub();
+      }
     } finally {
       this.cwdBrowse.disabled = false;
     }
@@ -1644,6 +1691,11 @@ const onboardingBackBtn = $('#onboarding-back');
 const onboardingNextBtn = $('#onboarding-next');
 const onboardingFinishBtn = $('#onboarding-finish');
 const agentForm = $('#agent-form');
+const preferredEditorHeading = $('#preferred-editor-heading');
+const preferredEditorForm = $('#preferred-editor-form');
+const preferredEditorCommandInput = $('#preferred-editor-command');
+const preferredEditorArgsInput = $('#preferred-editor-args');
+const preferredEditorClearBtn = $('#preferred-editor-clear');
 const githubTokenForm = $('#github-token-form');
 const githubTokenInput = $('#github-token');
 const githubTokenClearBtn = $('#github-token-clear');
@@ -1683,6 +1735,10 @@ function setFormMode(mode, agent) {
   agentForm.command.value = agent?.command || '';
   agentForm.args.value = (agent?.args || []).join(' ');
   agentForm.interactive.checked = !!agent?.interactive;
+}
+
+function refreshPreferredEditorButtons() {
+  for (const card of cards) card.updatePreferredEditorButton();
 }
 
 function agentPayloadFromForm(form, includeId = false) {
@@ -1880,6 +1936,38 @@ async function loadGitHubToken() {
   if (data.hasToken === true) githubTokenInput.placeholder = 'token already saved';
 }
 
+async function loadPreferredEditorSettings() {
+  preferredEditorHeading.hidden = !canUsePreferredEditor;
+  preferredEditorForm.hidden = !canUsePreferredEditor;
+  preferredEditorCommandInput.value = '';
+  preferredEditorArgsInput.value = '';
+  preferredEditorConfigured = false;
+  if (!canUsePreferredEditor) {
+    refreshPreferredEditorButtons();
+    return;
+  }
+  const response = await fetch('/api/system/preferred-editor');
+  if (!response.ok) {
+    refreshPreferredEditorButtons();
+    return;
+  }
+  const data = await response.json().catch(() => ({}));
+  if (data.available !== true) {
+    preferredEditorHeading.hidden = true;
+    preferredEditorForm.hidden = true;
+    canUsePreferredEditor = false;
+    refreshPreferredEditorButtons();
+    return;
+  }
+  const editor = data.preferredEditor && typeof data.preferredEditor === 'object'
+    ? data.preferredEditor
+    : {};
+  preferredEditorCommandInput.value = typeof editor.command === 'string' ? editor.command : '';
+  preferredEditorArgsInput.value = Array.isArray(editor.args) ? editor.args.join(' ') : '';
+  preferredEditorConfigured = data.configured === true;
+  refreshPreferredEditorButtons();
+}
+
 function setNewProjectStatus(text, cls = '') {
   newProjectStatusEl.textContent = text;
   newProjectStatusEl.classList.remove('ok', 'warn', 'err');
@@ -1994,6 +2082,35 @@ agentForm.addEventListener('submit', async (submitEvent) => {
 
 $('#agent-cancel').addEventListener('click', (clickEvent) => { clickEvent.preventDefault(); setFormMode('add'); });
 $('#discover-btn').addEventListener('click', refreshDiscoverTable);
+preferredEditorForm.addEventListener('submit', async (submitEvent) => {
+  submitEvent.preventDefault();
+  const submitBtn = preferredEditorForm.querySelector('button[type="submit"]');
+  const submitLabel = submitBtn ? submitBtn.dataset.label || submitBtn.textContent : '';
+  if (submitBtn && !submitBtn.dataset.label) submitBtn.dataset.label = submitLabel;
+  const response = await fetch('/api/system/preferred-editor', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      command: preferredEditorCommandInput.value,
+      args: preferredEditorArgsInput.value.trim() ? preferredEditorArgsInput.value.trim().split(/\s+/) : [],
+    }),
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    alert(err.error || 'save failed');
+    return;
+  }
+  await loadPreferredEditorSettings();
+  if (submitBtn) {
+    submitBtn.textContent = 'Saved';
+    setTimeout(() => { submitBtn.textContent = submitBtn.dataset.label || submitLabel; }, 1200);
+  }
+});
+preferredEditorClearBtn.addEventListener('click', () => {
+  preferredEditorCommandInput.value = '';
+  preferredEditorArgsInput.value = '';
+  preferredEditorCommandInput.focus();
+});
 githubTokenForm.addEventListener('submit', async (submitEvent) => {
   submitEvent.preventDefault();
   const submitBtn = githubTokenForm.querySelector('button[type="submit"]');
@@ -2023,7 +2140,7 @@ $('#close-settings').addEventListener('click', () => settingsDialog.close());
 $('#open-settings').addEventListener('click', async () => {
   setFormMode('add');
   $('#discover-table tbody').replaceChildren();
-  await Promise.all([refreshAgentsTable(), loadGitHubToken()]);
+  await Promise.all([refreshAgentsTable(), loadPreferredEditorSettings(), loadGitHubToken()]);
   settingsDialog.showModal();
 });
 onboardingDialog.addEventListener('cancel', (cancelEvent) => cancelEvent.preventDefault());
@@ -2302,6 +2419,7 @@ window.addEventListener('keydown', handleKeyboardShortcut, true);
 (async () => {
   await loadHealth();
   await loadAgents();
+  await loadPreferredEditorSettings();
   await restoreLayout();
   await maybeStartOnboarding();
   setInterval(loadHealth, 10000);

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
           <span class="card-status"></span>
           <button type="button" class="card-github" aria-label="Create GitHub repository" title="Create GitHub repository" hidden><svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></button>
           <button type="button" class="card-open-term" aria-label="Open terminal" title="Open terminal"><span aria-hidden="true">&gt;_</span></button>
+          <button type="button" class="card-open-editor" aria-label="Open in preferred editor" title="Open in preferred editor" hidden><span aria-hidden="true">&lt;/&gt;</span></button>
           <button type="button" class="card-clone" aria-label="Clone session" title="Clone session"><svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/></svg></button>
         </div>
       </form>
@@ -130,6 +131,21 @@
           <thead><tr><th>ID</th><th>Command</th><th>Path</th><th></th></tr></thead>
           <tbody></tbody>
         </table>
+      </section>
+
+      <section>
+        <h3 id="preferred-editor-heading" hidden>Preferred code editor</h3>
+        <form id="preferred-editor-form" class="agent-form" hidden>
+          <div class="grid">
+            <label>Command<input type="text" id="preferred-editor-command" autocomplete="off" placeholder="code" spellcheck="false"></label>
+            <label>Args (space-separated, optional)<input type="text" id="preferred-editor-args" autocomplete="off" placeholder="--reuse-window" spellcheck="false"></label>
+          </div>
+          <div class="row">
+            <button type="button" id="preferred-editor-clear">Clear</button>
+            <button type="submit">Save editor</button>
+          </div>
+          <p class="footnote">Shows the <code>&lt;/&gt;</code> card button on the local loopback UI only. Concilium always appends the current working directory as the final argument.</p>
+        </form>
       </section>
 
       <section>

--- a/public/style.css
+++ b/public/style.css
@@ -619,6 +619,7 @@ main.has-expanded > .card:not(.expanded) { display: none; }
   max-width: 180px;
 }
 .card-controls-row .card-open-term,
+.card-controls-row .card-open-editor,
 .card-controls-row .card-clone,
 .card-controls-row .card-github {
   flex: 0 0 auto;
@@ -638,7 +639,13 @@ main.has-expanded > .card:not(.expanded) { display: none; }
   color: var(--text);
   border: 1px solid var(--border-strong);
 }
+.card-open-editor {
+  background: var(--bg-input);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+}
 .card-open-term:hover,
+.card-open-editor:hover,
 .card-controls-row .card-clone:hover,
 .card-controls-row .card-github:not([hidden]):hover { background: var(--bg-hover); }
 .card-controls-row .card-clone,
@@ -650,6 +657,7 @@ main.has-expanded > .card:not(.expanded) { display: none; }
   line-height: 1;
 }
 .card-open-term:disabled,
+.card-open-editor:disabled,
 .card-github:disabled {
   opacity: 0.6;
 }

--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { execFile } = require('child_process');
+const { execFile, spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const store = require('../store');
@@ -13,6 +13,7 @@ const GIT_CLONE_TIMEOUT_MS = 120000;
 const MAX_GITHUB_URL_LENGTH = 2048;
 const MAX_ISSUE_TITLE_LENGTH = 256;
 const MAX_ISSUE_BODY_BYTES = 65536;
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
 // REST issue-assignee login used by GitHub for Copilot assignment.
 const COPILOT_ISSUE_ASSIGNEE = 'Copilot';
 const COPILOT_ISSUE_ASSIGNEE_FALLBACK = 'copilot-swe-agent[bot]';
@@ -31,6 +32,64 @@ function hasConfiguredAgent(cfg) {
 
 function isOnboardingCompleted(cfg) {
   return cfg && cfg.onboardingCompleted === true;
+}
+
+function getPreferredEditor(cfg) {
+  const raw = cfg && cfg.preferredEditor && typeof cfg.preferredEditor === 'object'
+    ? cfg.preferredEditor
+    : {};
+  const command = typeof raw.command === 'string' ? raw.command.trim() : '';
+  const args = Array.isArray(raw.args)
+    ? raw.args.map((arg) => String(arg).trim()).filter(Boolean)
+    : [];
+  return { command, args };
+}
+
+function normalizeHostHeader(value) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const host = typeof raw === 'string' ? raw.split(',')[0].trim().toLowerCase() : '';
+  if (!host) return '';
+  if (host.startsWith('[')) {
+    const closingIndex = host.indexOf(']');
+    return closingIndex === -1 ? host.slice(1) : host.slice(1, closingIndex);
+  }
+  const firstColonIndex = host.indexOf(':');
+  const lastColonIndex = host.lastIndexOf(':');
+  if (firstColonIndex !== -1 && firstColonIndex === lastColonIndex) {
+    return host.slice(0, firstColonIndex);
+  }
+  return host;
+}
+
+function isLoopbackRequest(req) {
+  const forwardedHost = normalizeHostHeader(req.headers['x-forwarded-host']);
+  if (forwardedHost) return LOOPBACK_HOSTS.has(forwardedHost);
+  const host = normalizeHostHeader(req.headers.host || req.hostname);
+  return LOOPBACK_HOSTS.has(host);
+}
+
+function launchPreferredEditor(editor, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(editor.command, [...editor.args, cwd], {
+      cwd,
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      ...(process.platform === 'win32' ? { shell: true } : {}),
+    });
+    let settled = false;
+    child.once('error', (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    });
+    child.once('spawn', () => {
+      if (settled) return;
+      settled = true;
+      child.unref();
+      resolve();
+    });
+  });
 }
 
 function pickDirectoryMac() {
@@ -96,6 +155,80 @@ router.post('/pick-directory', async (req, res) => {
     else return res.status(501).json({ error: `picker not supported on ${process.platform}` });
 
     res.json({ path: picked });
+  } catch (err) {
+    res.status(500).json({ error: err.message || String(err) });
+  }
+});
+
+router.get('/preferred-editor', (req, res) => {
+  if (!isLoopbackRequest(req)) {
+    return res.json({
+      available: false,
+      configured: false,
+      preferredEditor: { command: '', args: [] },
+    });
+  }
+  const editor = getPreferredEditor(getConfig());
+  res.json({
+    available: true,
+    configured: !!editor.command,
+    preferredEditor: editor,
+  });
+});
+
+router.post('/preferred-editor', (req, res) => {
+  if (!isLoopbackRequest(req)) {
+    return res.status(403).json({ error: 'preferred editor is only available on the local loopback UI' });
+  }
+  const { command, args } = req.body || {};
+  if (command !== undefined && typeof command !== 'string') {
+    return res.status(400).json({ error: 'command must be a string' });
+  }
+  if (args !== undefined && !Array.isArray(args)) {
+    return res.status(400).json({ error: 'args must be an array of strings' });
+  }
+  if (Array.isArray(args) && args.some((arg) => typeof arg !== 'string')) {
+    return res.status(400).json({ error: 'args must be an array of strings' });
+  }
+  const editor = {
+    command: typeof command === 'string' ? command.trim() : '',
+    args: Array.isArray(args) ? args.map((arg) => arg.trim()).filter(Boolean) : [],
+  };
+  const cfg = getConfig();
+  if (editor.command) cfg.preferredEditor = editor;
+  else delete cfg.preferredEditor;
+  saveConfig(cfg);
+  res.json({ ok: true, configured: !!editor.command });
+});
+
+router.post('/open-editor', async (req, res) => {
+  try {
+    if (!isLoopbackRequest(req)) {
+      return res.status(403).json({ error: 'opening the preferred editor is only available on the local loopback UI' });
+    }
+    const rawDir = req.body && req.body.path;
+    if (!rawDir || typeof rawDir !== 'string') {
+      return res.status(400).json({ error: 'path required' });
+    }
+    const editor = getPreferredEditor(getConfig());
+    if (!editor.command) {
+      return res.status(400).json({ error: 'set a preferred code editor in Settings first' });
+    }
+    const resolved = path.resolve(expandTilde(rawDir));
+    let stats;
+    try {
+      stats = await fs.promises.stat(resolved);
+    } catch (err) {
+      if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+        return res.status(400).json({ error: 'working directory does not exist' });
+      }
+      throw err;
+    }
+    if (!stats.isDirectory()) {
+      return res.status(400).json({ error: 'working directory must be a directory' });
+    }
+    await launchPreferredEditor(editor, resolved);
+    res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message || String(err) });
   }


### PR DESCRIPTION
## Summary
- add a local-loopback-only preferred editor setting and open-editor API
- add a session-card editor button between Terminal and Clone when an editor is configured
- document the new setting and endpoints

Fixes #106